### PR TITLE
ci: build OpenTelemetryApi.xcframework

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-12
+
+    steps:
+      - name: Checkout self
+        uses: actions/checkout@v4
+        with:
+          path: opentelemetry-swift-packages
+
+      - name: Checkout opentelemetry-swift
+        uses: actions/checkout@v4
+        with:
+          repository: open-telemetry/opentelemetry-swift
+          path: opentelemetry-swift
+          ref: main
+
+      - name: Build
+        working-directory: ./opentelemetry-swift-packages
+        run: |
+          ./scripts/build.sh --source ../opentelemetry-swift --target OpenTelemetryApi
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenTelemetryApi.xcframework
+          path: ./opentelemetry-swift-packages/artifacts/OpenTelemetryApi.xcframework.zip
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+archives/
+artifacts/
+frameworks/

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+set -e
+
+source="../opentelemetry-swift"
+target="OpenTelemetryApi"
+
+# Usage function
+function usage() {
+    echo "Usage: $0 [-s <source>] [-t <target>]"
+    echo "  -s, --source    Specify the source directory"
+    echo "  -t, --target    Specify the target directory"
+    echo "  -h, --help      Display this help message"
+    exit 0
+}
+
+# Parse command-line arguments
+while (( "$#" )); do
+    case "$1" in
+        -s|--source)
+                source="$2"
+                shift 2
+                ;;
+        -t|--target)
+                target="$2"
+                shift 2
+                ;;
+        -h|--help)
+                usage
+                ;;
+        --) # end argument parsing
+            shift
+            break
+            ;;
+        -*|--*=) # unsupported flags
+            echo "Error: Unsupported flag $1" >&2
+            exit 1
+            ;;
+        *) # preserve positional arguments
+            PARAMS="$PARAMS $1"
+            shift
+            ;;
+    esac
+done
+
+echo "Source: $source"
+echo "Target: $target"
+
+# Replace all type: .static with .dynamic
+# Static libraries can't be bundled into xcframeworks hence the need to replace them with dynamic libraries
+function update_package_swift() {
+    file=$1
+    echo "Updating $file"
+    sed -i '' 's/.static/.dynamic/g' $file
+}
+
+# Build the scheme for the platform
+function build() {
+    scheme=$1
+    platform=$2
+    echo "Building $scheme for $platform"
+    xcodebuild archive -workspace $source \
+        -scheme $scheme \
+        -destination "generic/platform=$platform" \
+        -archivePath "archives/$scheme/$platform" \
+        -derivedDataPath ".build" \
+        SKIP_INSTALL=NO \
+        BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+        | xcpretty
+    echo "Done building $scheme for $platform"
+}
+
+# Create xcframework from the archives
+function package() {
+    scheme=$1
+    shift
+    platforms=("$@")
+
+    args=()
+    for platform in "${platforms[@]}"; do
+        echo "Adding $platform to $scheme.xcframework"
+
+        framework_path="archives/$scheme/$platform.xcarchive/Products/usr/local/lib/$scheme.framework"
+
+        # For some reason, the dsym path needs to be absolute, else framework creation fails
+        dsym_path=`readlink -f "archives/$scheme/$platform.xcarchive/dSYMs/$scheme.framework.dSYM"`
+
+        args+=("-framework" "$framework_path" "-debug-symbols" "$dsym_path")
+    done
+
+    echo "Removing archives/$scheme.xcframework"
+    rm -rf "frameworks/$scheme.xcframework"
+
+    echo "Creating $scheme.xcframework"
+    xcodebuild -create-xcframework "${args[@]}" -output "frameworks/$scheme.xcframework" | xcpretty
+    echo "Done creating $scheme.xcframework"
+}
+
+# Zip the xcframework
+function compress() {
+    scheme=$1
+    echo "Removing artifacts/$scheme.xcframework.zip"
+    rm -rf "artifacts/$scheme.xcframework.zip"
+
+    echo "Zipping $scheme.xcframework"
+    mkdir -p "artifacts"
+
+    # by default zip will include the full path of the files in the zip file
+    # -j will not include the path but it doesn't work with -r
+    pushd "frameworks/$scheme.xcframework"
+    zip -r "../../artifacts/$scheme.xcframework.zip" *
+    popd
+    echo "Done zipping $scheme.xcframework"
+}
+
+platforms=(
+    "iOS"
+    "iOS Simulator"
+    "tvOS"
+    "tvOS Simulator"
+)
+
+update_package_swift "$source/Package.swift"
+update_package_swift "$source/Package@swift-5.6.swift"
+update_package_swift "$source/Package@swift-5.9.swift"
+
+for platform in "${platforms[@]}"; do
+    build $target "$platform"
+done
+
+package $target "${platforms[@]}"
+compress $target


### PR DESCRIPTION
### What and why?

OpenTelemetryApi.xcframework is first step of supporting OpenTelemetryApi for Cocoapods and Carthage.

### How?

Follows the RFC
- Update packages.swift in opentelemetry-swift repo
- Build OpenTelemetryApi for iOS, iOS Simulator, tvOS and tvOS Simulator
- Package it

The final artifact is uploaded as part of PR artifacts.

<img width="776" alt="image" src="https://github.com/DataDog/opentelemetry-swift-packages/assets/8882380/86767e7e-aa48-40a8-b59e-14adb71e4542">
