### PR TITLE
ci: add ability to push release using release.sh

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ jobs:
           repository: open-telemetry/opentelemetry-swift
           path: opentelemetry-swift
           ref: main
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Build
         working-directory: ./opentelemetry-swift-packages
@@ -33,5 +35,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: OpenTelemetryApi.xcframework
-          path: ./opentelemetry-swift-packages/artifacts/OpenTelemetryApi.xcframework.zip
+          path: |
+            ./opentelemetry-swift-packages/artifacts/OpenTelemetryApi.xcframework.zip
+            ./opentelemetry-swift-packages/artifacts/release_notes.md
           if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ iOSInjectionProject/
 archives/
 artifacts/
 frameworks/
+.DS_Store

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -e
+
+# Usage function
+function usage() {
+    echo "Usage: $0 [-v <version>]"
+    echo "  -v, --version   Specify the version"
+    echo "  -h, --help      Display this help message"
+    exit 0
+}
+
+# Parse command-line arguments
+while (( "$#" )); do
+    case "$1" in
+        -s|--source)
+                source="$2"
+                shift 2
+                ;;
+        -v|--version)
+                version="$2"
+                shift 2
+                ;;
+        -h|--help)
+                usage
+                ;;
+        --) # end argument parsing
+            shift
+            break
+            ;;
+        -*|--*=) # unsupported flags
+            echo "Error: Unsupported flag $1" >&2
+            exit 1
+            ;;
+        *) # preserve positional arguments
+            PARAMS="$PARAMS $1"
+            shift
+            ;;
+    esac
+done
+
+# Check required arguments
+if [ -z "$version" ]; then
+    echo "Error: Missing version"
+    usage
+fi
+
+echo "Version: $version"
+
+gh release create $version \
+    artifacts/OpenTelemetryApi.xcframework.zip \
+    --title "OpenTelemetry Swift $version" \
+    --notes-file artifacts/release_notes.md


### PR DESCRIPTION
### What and why?

Automate release.

### How?

This PR is built on top of PR #1 The artifacts created by the #1 PR are pushed in the target release.

Sample: https://github.com/DataDog/opentelemetry-swift-packages/releases/tag/1.9.1