### PR TITLE
fix: make sure the target Package.swift file exists before update

### DIFF
--- a/OpenTelemetryApi.json
+++ b/OpenTelemetryApi.json
@@ -1,4 +1,5 @@
 {
   "1.9.1": "https://github.com/DataDog/opentelemetry-swift-packages/releases/download/1.9.1/OpenTelemetryApi.zip",
-  "1.9.2": "https://github.com/DataDog/opentelemetry-swift-packages/releases/download/1.9.2/OpenTelemetryApi.zip"
+  "1.9.2": "https://github.com/DataDog/opentelemetry-swift-packages/releases/download/1.9.2/OpenTelemetryApi.zip",
+  "1.6.0": "https://github.com/DataDog/opentelemetry-swift-packages/releases/download/1.6.0/OpenTelemetryApi.zip"
 }

--- a/OpenTelemetrySwiftApi.podspec
+++ b/OpenTelemetrySwiftApi.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "OpenTelemetrySwiftApi"
-  s.version = "1.9.2"
+  s.version = "1.6.0"
   s.summary = "Unofficial OpenTelemetry API for Swift maintained by Datadog"
   s.description = "This is an unofficial OpenTelemetry API for Swift maintained by Datadog team and primarily used by Datadog SDK for iOS. It follows the official OpenTelemetry releases and provides CocoaPods compatible distribution."
 
@@ -223,6 +223,6 @@ LICENSE
   s.swift_version = "5.7.1"
   s.ios.deployment_target = "11.0"
   s.tvos.deployment_target = "11.0"
-  s.source = { http: "#{s.homepage}/releases/download/#{s.version}/OpenTelemetryApi.zip", sha1: "58a8ab0e82526c6596ce30e99331c43fe23b0354" }
+  s.source = { http: "#{s.homepage}/releases/download/#{s.version}/OpenTelemetryApi.zip", sha1: "dcf5c60f57d04f9f4107cd0749731e59e833c25a" }
   s.vendored_frameworks = 'OpenTelemetryApi/OpenTelemetryApi.xcframework'
 end

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -56,6 +56,11 @@ echo "Target: $target"
 # Static libraries can't be bundled into xcframeworks hence the need to replace them with dynamic libraries
 function update_package_swift() {
     file=$1
+    # check if the file exists
+    if [ ! -f $file ]; then
+        echo "File $file does not exist"
+        return
+    fi
     echo "Updating $file"
     sed -i '' 's/.static/.dynamic/g' $file
 }


### PR DESCRIPTION
### What and why?

I wanted to publish 1.6.0 version of the SDK and it failed because Package@swift-5.9.swift doesn't exist.

### How?

Before updating the file, make sure it exists.
