### PR TITLE
feat: add support for macOS

### DIFF
--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -12,7 +12,7 @@ on:
   push:
     branches:
     # For testing purposes, use your branch name here
-      - "ganeshnj/fix/commit-signature-valid"
+      - "ganeshnj/feat/macos-support"
 
 env:
   GH_TOKEN: ${{ github.token }}

--- a/OpenTelemetrySwiftApi.podspec
+++ b/OpenTelemetrySwiftApi.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "OpenTelemetrySwiftApi"
-  s.version = "1.6.0"
+  s.version = "1.9.2"
   s.summary = "Unofficial OpenTelemetry API for Swift maintained by Datadog"
   s.description = "This is an unofficial OpenTelemetry API for Swift maintained by Datadog team and primarily used by Datadog SDK for iOS. It follows the official OpenTelemetry releases and provides CocoaPods compatible distribution."
 
@@ -223,6 +223,7 @@ LICENSE
   s.swift_version = "5.7.1"
   s.ios.deployment_target = "11.0"
   s.tvos.deployment_target = "11.0"
-  s.source = { http: "#{s.homepage}/releases/download/#{s.version}/OpenTelemetryApi.zip", sha1: "dcf5c60f57d04f9f4107cd0749731e59e833c25a" }
+  s.osx.deployment_target = "10.13"
+  s.source = { http: "#{s.homepage}/releases/download/#{s.version}/OpenTelemetryApi.zip", sha1: "15b2f80206e9f8964744cb07a4943e4477d35b33" }
   s.vendored_frameworks = 'OpenTelemetryApi/OpenTelemetryApi.xcframework'
 end

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -80,6 +80,8 @@ function build() {
         archs="arm64"
     elif [ "$platform" == "tvOS Simulator" ]; then
         archs="x86_64 arm64"
+    elif [ "$platform" == "macOS" ]; then
+        archs="x86_64 arm64"
     fi
 
     echo "Building $scheme for $platform"
@@ -115,6 +117,9 @@ function build() {
             ;;
         "tvOS Simulator")
             release_folder="Release-appletvsimulator"
+            ;;
+        "macOS")
+            release_folder="Release" # for some reason, the directory is not suffixed with the platform name
             ;;
     esac
 
@@ -212,6 +217,7 @@ platforms=(
     "iOS Simulator"
     "tvOS"
     "tvOS Simulator"
+    "macOS"
 )
 
 update_package_swift "$source/Package.swift"


### PR DESCRIPTION
### What and why?

We want to support macOS in dd-sdk-ios

### How?

Added macOS as supported platform.


I republished 1.9.2 version using this branch https://github.com/DataDog/opentelemetry-swift-packages/releases/tag/1.9.2 and it worked fine.

Check action https://github.com/DataDog/opentelemetry-swift-packages/actions/runs/8816584295
