### PR TITLE
Update OpenTelemetryApi.json

### DIFF
--- a/OpenTelemetryApi.json
+++ b/OpenTelemetryApi.json
@@ -1,5 +1,3 @@
 {
-  "1.9.1": "https://github.com/DataDog/opentelemetry-swift-packages/releases/download/1.9.1/OpenTelemetryApi.zip",
-  "1.9.2": "https://github.com/DataDog/opentelemetry-swift-packages/releases/download/1.9.2/OpenTelemetryApi.zip",
   "1.6.0": "https://github.com/DataDog/opentelemetry-swift-packages/releases/download/1.6.0/OpenTelemetryApi.zip"
 }


### PR DESCRIPTION
### What and why?

other versions don't exist.

### How?

Removed existent versions.
