### PR TITLE
Pin actions to commit hash

### DIFF
--- a/.github/workflows/automation.yaml
+++ b/.github/workflows/automation.yaml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-14
 
     steps:
       - name: Environment information
@@ -59,12 +59,12 @@ jobs:
           fi
 
       - name: Checkout self
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: opentelemetry-swift-packages
 
       - name: Checkout opentelemetry-swift
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: open-telemetry/opentelemetry-swift
           path: opentelemetry-swift
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload artifacts
         if: ${{ env.SKIP_RELEASE != 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: OpenTelemetryApi
           path: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,16 +9,16 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-14
 
     steps:
       - name: Checkout self
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: opentelemetry-swift-packages
 
       - name: Checkout opentelemetry-swift
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: open-telemetry/opentelemetry-swift
           path: opentelemetry-swift
@@ -32,7 +32,7 @@ jobs:
           ./scripts/build.sh --source ../opentelemetry-swift --target OpenTelemetryApi
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: OpenTelemetryApi
           path: |
@@ -40,11 +40,11 @@ jobs:
           if-no-files-found: error
 
   spm:
-    runs-on: macos-12
+    runs-on: macos-14
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Test
         run: |
           swift test | xcbeautify

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,19 +17,10 @@ jobs:
         with:
           path: opentelemetry-swift-packages
 
-      - name: Checkout opentelemetry-swift
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: open-telemetry/opentelemetry-swift
-          path: opentelemetry-swift
-          ref: main
-          fetch-depth: 0
-          fetch-tags: true
-
       - name: Build
         working-directory: ./opentelemetry-swift-packages
         run: |
-          ./scripts/build.sh --source ../opentelemetry-swift --target OpenTelemetryApi
+          ./scripts/build.sh --source . --target OpenTelemetryApi
 
       - name: Upload artifacts
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0

--- a/Package.swift
+++ b/Package.swift
@@ -13,10 +13,15 @@ let package = Package(
         .watchOS(.v7)
     ],
     products: [
-        .library(name: "OpenTelemetryApi", targets: ["OpenTelemetryApi"]),
+        .library(name: "OpenTelemetryApi", type: .dynamic, targets: ["OpenTelemetryApi"]),
+        // This is a dummy library to make sure the package has more than one library,
+        // and xcodebuild can discover OpenTelemetryApi as an individual target.
+        .library(name: "Empty", targets: ["Empty"]),
     ],
     targets: [
         .target(name: "OpenTelemetryApi",
+                dependencies: []),
+        .target(name: "Empty",
                 dependencies: []),
         .testTarget(name: "OpenTelemetryApiTests",
                     dependencies: ["OpenTelemetryApi"],

--- a/Sources/Empty/Dummy.swift
+++ b/Sources/Empty/Dummy.swift
@@ -1,0 +1,1 @@
+// This is to make the Empty library buildable.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-source="../opentelemetry-swift"
-github_url="https://github.com/open-telemetry/opentelemetry-swift"
 target="OpenTelemetryApi"
 
 # Usage function
@@ -51,19 +49,6 @@ done
 
 echo "Source: $source"
 echo "Target: $target"
-
-# Replace all type: .static with .dynamic
-# Static libraries can't be bundled into xcframeworks hence the need to replace them with dynamic libraries
-function update_package_swift() {
-    file=$1
-    # check if the file exists
-    if [ ! -f $file ]; then
-        echo "File $file does not exist"
-        return
-    fi
-    echo "Updating $file"
-    sed -i '' 's/.static/.dynamic/g' $file
-}
 
 
 # Build the scheme for the platform
@@ -142,17 +127,6 @@ function package() {
         framework_path="archives/$scheme/$platform.xcarchive/Products/usr/local/lib/$scheme.framework"
 
         # For some reason, the dsym path needs to be absolute, else framework creation fails
-        echo "ls ."
-        ls -al "."
-        echo "ls archives"
-        ls -al "archives"
-        echo "ls archives/$scheme"
-        ls -al "archives/$scheme"
-        echo "ls archives/$scheme/$platform.xcarchive"
-        ls -al "archives/$scheme/$platform.xcarchive"
-        echo "ls archives/$scheme/$platform.xcarchive/dSYMs"
-        ls -al "archives/$scheme/$platform.xcarchive/dSYMs"
-
         echo "readlink -f archives/$scheme/$platform.xcarchive/dSYMs/$scheme.framework.dSYM"
         dsym_path=`readlink -f "archives/$scheme/$platform.xcarchive/dSYMs/$scheme.framework.dSYM"`
 
@@ -231,10 +205,6 @@ platforms=(
     "tvOS Simulator"
     "macOS"
 )
-
-update_package_swift "$source/Package.swift"
-update_package_swift "$source/Package@swift-5.6.swift"
-update_package_swift "$source/Package@swift-5.9.swift"
 
 for platform in "${platforms[@]}"; do
     build $target "$platform"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -142,6 +142,18 @@ function package() {
         framework_path="archives/$scheme/$platform.xcarchive/Products/usr/local/lib/$scheme.framework"
 
         # For some reason, the dsym path needs to be absolute, else framework creation fails
+        echo "ls ."
+        ls -al "."
+        echo "ls archives"
+        ls -al "archives"
+        echo "ls archives/$scheme"
+        ls -al "archives/$scheme"
+        echo "ls archives/$scheme/$platform.xcarchive"
+        ls -al "archives/$scheme/$platform.xcarchive"
+        echo "ls archives/$scheme/$platform.xcarchive/dSYMs"
+        ls -al "archives/$scheme/$platform.xcarchive/dSYMs"
+
+        echo "readlink -f archives/$scheme/$platform.xcarchive/dSYMs/$scheme.framework.dSYM"
         dsym_path=`readlink -f "archives/$scheme/$platform.xcarchive/dSYMs/$scheme.framework.dSYM"`
 
         args+=("-framework" "$framework_path" "-debug-symbols" "$dsym_path")


### PR DESCRIPTION
### What and why?

For security, third party github actions are pinned to exact commit hash instead of a floating tag version number
