### PR TITLE
Revert 1.6.0 in OpenTelemetryApi.json

### DIFF
--- a/OpenTelemetryApi.json
+++ b/OpenTelemetryApi.json
@@ -1,3 +1,4 @@
 {
+  "1.6.0": "https://github.com/DataDog/opentelemetry-swift-packages/releases/download/1.6.0/OpenTelemetryApi.zip",
   "1.13.0": "https://github.com/DataDog/opentelemetry-swift-packages/releases/download/1.13.0/OpenTelemetryApi.zip"
 }


### PR DESCRIPTION

### What and why?

The `OpenTelemetryApi.json` must be listing all released versions for Carthage compatibility.

### How?

Adding 1.6.0 back to the `OpenTelemetryApi.json`.