### PR TITLE
RUM-8558 chore: Export GH_TOKEN for release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,9 @@ on:
     tags:
       - '*'
 
+env:
+  GH_TOKEN: ${{ github.token }}
+
 jobs:
   release:
     runs-on: macos-14


### PR DESCRIPTION
### What and why?

📦 Fixing issue in `release.yaml` that caused previous tag (1.13.0) to fail:
```
......................................
┌──────────────────────────────────────┐
│ make publish-github VERSION='1.13.0' │
└──────────────────────────────────────┘
./scripts/publish_github.sh --version "1.13.0"
...
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
make: *** [publish-github] Error 4
```

### How?

Re-exporting `GH_TOKEN` to job's environment, so it can be used by `gh` CLI.
