### PR TITLE
chore: Bump Carthage & CocoaPods to 1.13.0

### DIFF
--- a/OpenTelemetryApi.json
+++ b/OpenTelemetryApi.json
@@ -1,3 +1,4 @@
 {
-  "1.6.0": "https://github.com/DataDog/opentelemetry-swift-packages/releases/download/1.6.0/OpenTelemetryApi.zip"
+  "1.6.0": "https://github.com/DataDog/opentelemetry-swift-packages/releases/download/1.6.0/OpenTelemetryApi.zip",
+  "1.13.0": "https://github.com/DataDog/opentelemetry-swift-packages/releases/download/1.13.0/OpenTelemetryApi.zip"
 }

--- a/OpenTelemetrySwiftApi.podspec
+++ b/OpenTelemetrySwiftApi.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "OpenTelemetrySwiftApi"
-  s.version = "1.6.0"
+  s.version = "1.13.0"
   s.summary = "Unofficial OpenTelemetry API for Swift maintained by Datadog"
   s.description = "This is an unofficial OpenTelemetry API for Swift maintained by Datadog team and primarily used by Datadog SDK for iOS. It follows the official OpenTelemetry releases and provides CocoaPods compatible distribution."
 
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '12.0'
   s.tvos.deployment_target = '12.0'
 
-  s.source = { http: "#{s.homepage}/releases/download/#{s.version}/OpenTelemetryApi.zip", sha1: "5db74581718b9cf223ce6ed66aa47fbfb9d5b521" }
+  s.source = { http: "#{s.homepage}/releases/download/#{s.version}/OpenTelemetryApi.zip", sha1: "ecf995fc60bf394130faa21835030e271519ea92" }
   s.vendored_frameworks = 'OpenTelemetryApi/OpenTelemetryApi.xcframework'
 end


### PR DESCRIPTION
This PR updates Carthage and CocoaPods to version 1.13.0.