### PR TITLE
RUM-9224 Do not enforce dynamic linking in SPM package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,22 @@ let package = Package(
     ]
 )
 
+/// Customize package for building XCFramework:
 if ProcessInfo.processInfo.environment["DD_XCODEBUILD_PATCH"] != nil {
+    // RUM-9224: Enforce dynamic linking because `xcodebuild` does not generate dSYMs
+    // when linking statically (static linking is the default starting from Xcode 15.0).
+    //
+    // Ref.: https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes
+    // > A new linker has been written to significantly speed up static linking.
+    // > It’s the default for all macOS, iOS, tvOS and visionOS binaries.
+    package.products = package.products.map { product in
+        if let library = product as? Product.Library {
+            return .library(name: library.name, type: .dynamic, targets: library.targets)
+        } else {
+            return product
+        }
+    }
+
     // Workaround for `xcodebuild` failing to detect `OpenTelemetryApi` as an individual target
     // when the package has only one library.
     //

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .watchOS(.v7)
     ],
     products: [
-        .library(name: "OpenTelemetryApi", type: .dynamic, targets: ["OpenTelemetryApi"]),
+        .library(name: "OpenTelemetryApi", targets: ["OpenTelemetryApi"]),
     ],
     targets: [
         .target(name: "OpenTelemetryApi", dependencies: []),

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -45,6 +45,8 @@ done
 
 echo_info "Source: $source"
 echo_info "Target: $target"
+echo_info "xcodebuild -version"
+xcodebuild -version
 
 # Build the scheme for the platform
 function build() {


### PR DESCRIPTION
### What and why?

📦 This PR removes `type: .dynamic` enforcement from `Package.swift` which is not required (it was added in https://github.com/DataDog/opentelemetry-swift-packages/pull/22 by mistake). This change will allow Xcode to automatically choose the appropriate linkage type when using SPM.

### How?

Two changes in `Package.swift`:
- ```diff
  - type: .dynamic
  ```
- Added a patch to enforce dynamic linking when building with `xcodebuild`, as Xcode 15 defaults to static linking which prevents dSYM generation. This ensures that debug symbols are properly produced for XCFramework. The previous version of `OpenTelemetryApi` (1.6.0) was built using Xcode 14, so this problem didn't stem.

Ref.: https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes
> A new linker has been written to significantly speed up static linking.
> It’s the default for all macOS, iOS, tvOS and visionOS binaries.