### PR TITLE
Allow re-publishing binary

### DIFF
--- a/.github/workflows/republish.yaml
+++ b/.github/workflows/republish.yaml
@@ -1,0 +1,30 @@
+name: Republish
+
+permissions:
+  contents: write  # Required for creating GitHub Releases and uploading artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to republish (e.g. 1.2.3)'
+        required: true
+        type: string
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  republish:
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          path: opentelemetry-swift-packages
+
+      - name: Republish GH Release
+        working-directory: ./opentelemetry-swift-packages
+        run: |
+          make republish-github VERSION=${{ inputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test xcframework publish-github bump-carthage-version
+.PHONY: test xcframework publish-github republish-github bump-carthage-version
 
 ECHO_TITLE=$(PWD)/scripts/utils/echo-color.sh --title
 ECHO_ERROR=$(PWD)/scripts/utils/echo-color.sh --err
@@ -24,6 +24,12 @@ publish-github:
 	@$(call require_param,VERSION)
 	@$(ECHO_TITLE) "make publish-github VERSION='$(VERSION)'"
 	./scripts/publish_github.sh --version "$(VERSION)"
+
+republish-github:
+	@$(call require_param,VERSION)
+	@$(ECHO_TITLE) "make republish-github VERSION='$(VERSION)'"
+	./scripts/build.sh --source . --target OpenTelemetryApi
+	./scripts/publish_github.sh --version "$(VERSION)" --update
 
 bump-carthage-version:
 	@$(call require_param,VERSION)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -70,7 +70,7 @@ function build() {
     elif [ "$platform" = "visionOS" ]; then
         archs="arm64 arm64e"
     elif [ "$platform" = "visionOS Simulator" ]; then
-        archs="x86_64 arm64"
+        archs="arm64"
     elif [ "$platform" = "macOS" ]; then
         archs="x86_64 arm64"
     fi

--- a/scripts/publish_github.sh
+++ b/scripts/publish_github.sh
@@ -3,10 +3,13 @@
 set -e
 source ./scripts/utils/echo-color.sh
 
+update=false
+
 # Usage function
 function usage() {
-    echo "Usage: $0 [-v <version>]"
+    echo "Usage: $0 [-v <version>] [--update]"
     echo "  -v, --version   Specify the version"
+    echo "  -u, --update    Update assets and notes of an existing release"
     echo "  -h, --help      Display this help message"
     exit 0
 }
@@ -16,6 +19,10 @@ while (( "$#" )); do
         -v|--version)
                 version="$2"
                 shift 2
+                ;;
+        -u|--update)
+                update=true
+                shift
                 ;;
         -h|--help)
                 usage
@@ -36,11 +43,17 @@ while (( "$#" )); do
 done
 
 echo_info "Checking if the github release $version exists"
-if gh release view $version > /dev/null; then
-    echo_err "Github release $version exists"
+if gh release view $version > /dev/null 2>&1; then
+    if [ "$update" = true ]; then
+        echo_info "Updating existing github release $version"
+        gh release upload $version artifacts/OpenTelemetryApi.zip --clobber
+        gh release edit $version --notes-file artifacts/version_info.md
+    else
+        echo_err "Github release $version already exists. Use --update to replace its assets."
+        exit 1
+    fi
 else
-    echo_info "Github release $version does not exist"
-    echo "Creating github draft release $version"
+    echo_info "Creating github draft release $version"
     gh release create $version \
         artifacts/OpenTelemetryApi.zip \
         --title "$version" \


### PR DESCRIPTION
### What and why?

Add support for manually re-publishing a GitHub release when the binary needs to be rebuilt for an existing version (e.g. to add a new platform or fix a build issue), without having to delete and recreate the release tag.

### How?

- Added `--update` flag to `publish_github.sh`: when a release already exists, it replaces the zip asset in-place (`gh release upload --clobber`) and updates the release notes (`gh release edit --notes-file`), preserving the release tag, title, and published state.
- Added `republish-github` Makefile target that rebuilds the xcframework and then publishes with `--update`.
- Added a `workflow_dispatch` GitHub Actions workflow (`republish.yaml`) that takes a `version` input and runs `make republish-github`, allowing manual re-publication from the GitHub UI.
- Fixed `visionOS Simulator` architecture to `arm64` only (removed `x86_64`).

